### PR TITLE
update aiortc version to 1.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/jimdragongod/mediasoup-client-pysdk"
 [tool.poetry.dependencies]
 python = "^3.8.0"
 pydantic = "^1.8.1"
-aiortc = "^1.2.0"
-pyee = "^8.1.0"
+aiortc = "^1.3.2"
+pyee = "^9.0.4"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
pymediasoup has upgraded aiortc to version 1.3.2
aiortc upgrade from version 1.2.0 to version 1.3.2 can avoid vpx and opus dependency problem on Windows